### PR TITLE
stylelint version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sass-loader": "^7.1.0",
     "sitemap-webpack-plugin": "^0.6.0",
     "style-loader": "^0.23.1",
-    "stylelint": "^8.3.0",
+    "stylelint": "^8.3.1",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-scss": "^3.4.3",
     "stylelint-webpack-plugin": "^0.10.5",


### PR DESCRIPTION
There's a bug in 8.3.0 of style lint, where the font declaration inside a font-face webfont was giving a false error, see: https://github.com/stylelint/stylelint/issues/3033